### PR TITLE
ENH: Transition to Python 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ it is not mandatory. Once setup, run
 
 ```bash
 pip install -r requirements.txt
-pip install -r requirements_additional.txt
 ```
 
 You can then clone or download the scoring system. Once cloned or

--- a/challenge_scoring/metrics/scoring.py
+++ b/challenge_scoring/metrics/scoring.py
@@ -14,8 +14,6 @@ from dipy.segment.clustering import QuickBundles
 from dipy.segment.metric import AveragePointwiseEuclideanMetric
 from dipy.tracking.metrics import length as slength
 
-from tractconverter.formats.tck import TCK
-
 from challenge_scoring import NB_POINTS_RESAMPLE
 from challenge_scoring.io.streamlines import get_tracts_voxel_space_for_dipy, \
                                        save_tracts_tck_from_dipy_voxel_space, \
@@ -202,8 +200,7 @@ def score_submission(streamlines_fname,
     if len(rejected_streamlines) > 0 and save_full_nc:
         out_nc_fname = os.path.join(segmented_out_dir,
                                     '{}_NC.tck'.format(segmented_base_name))
-        out_file = TCK.create(out_nc_fname)
-        save_tracts_tck_from_dipy_voxel_space(out_file, ref_anat_fname,
+        save_tracts_tck_from_dipy_voxel_space(out_nc_fname, ref_anat_fname,
                                               rejected_streamlines)
 
     VC /= total_strl_count
@@ -211,8 +208,8 @@ def score_submission(streamlines_fname,
     NC = len(rejected_streamlines) / total_strl_count
     VCWP = 0
 
-    nb_VB_found = [v['nb_streamlines'] > 0 for k, v in found_vbs_info.iteritems()].count(True)
-    streamlines_per_bundle = {k: v['nb_streamlines'] for k, v in found_vbs_info.iteritems() if v['nb_streamlines'] > 0}
+    nb_VB_found = [v['nb_streamlines'] > 0 for k, v in found_vbs_info.items()].count(True)
+    streamlines_per_bundle = {k: v['nb_streamlines'] for k, v in found_vbs_info.items() if v['nb_streamlines'] > 0}
 
     scores = {}
     scores['version'] = 2

--- a/challenge_scoring/utils/attributes.py
+++ b/challenge_scoring/utils/attributes.py
@@ -23,14 +23,14 @@ def save_attribs(attribs_filepath, attribs):
 
 
 def merge_attribs(orig_attribs, additional_attribs, overwrite=False):
-    for fname, attr in additional_attribs.iteritems():
+    for fname, attr in additional_attribs.items():
         orig_value = orig_attribs.get(fname, None)
 
         if orig_value is None:
             # Item was not in dictionary
             orig_attribs[fname] = attr
         else:
-            for new_attr, new_val in attr.iteritems():
+            for new_attr, new_val in attr.items():
                 orig_attrib_val = orig_value.get(new_attr, None)
 
                 # If we didn't find the attribute, or the attribute

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-setuptools==2.2
-numpy==1.11.2
-scipy==0.18.1
-nibabel==2.1.0
-Cython==0.25.2
-dipy==0.11.0
+setuptools
+numpy
+scipy
+nibabel
+Cython
+dipy

--- a/requirements_additional.txt
+++ b/requirements_additional.txt
@@ -1,1 +1,0 @@
-https://github.com/MarcCote/tractconverter/archive/master.zip


### PR DESCRIPTION
Transition to Python 3.

Python 2 is no longer supported. This implies that the `TractConverter`
tool is superseded by `NiBabel`.