### PR TITLE
BUG: Fix `QuickBundles` instantiation

### DIFF
--- a/challenge_scoring/metrics/invalid_connections.py
+++ b/challenge_scoring/metrics/invalid_connections.py
@@ -8,7 +8,7 @@ import logging
 import os
 import random
 
-import dipy.segment.quickbundles as qb
+from dipy.segment.clustering import QuickBundles
 import numpy as np
 from scipy.spatial.distance import cdist
 
@@ -114,10 +114,8 @@ def group_and_assign_ibs(candidate_streamlines, ROIs,
     random.shuffle(candidate_streamlines)
 
     # TODO threshold on distance as arg for other datasets
-    out_data = qb.QuickBundles(candidate_streamlines,
-                               dist_thr=20.,
-                               pts=12)
-    clusters = out_data.clusters()
+    qb = QuickBundles(threshold=20., metric="MDF_12points")
+    clusters = qb.cluster(candidate_streamlines)
 
     logging.debug("Found {} potential IB clusters".format(len(clusters)))
 


### PR DESCRIPTION
Fix `QuickBundles` instantiation.

`dipy.segment.quickbundles. QuickBundles` was deprecated in favor of
``dipy.segment.clustering.QuickBundles` by DIPY commit
https://github.com/nipy/dipy/commit/a809bb58c367d377cf3d1366a3a9ceaafd5c6fae

which as merged in DIPY 0.9.2 PR
https://github.com/nipy/dipy/pull/568

And it was removed in DIPY 1.0.0 PR
https://github.com/nipy/dipy/pull/1827