### PR TITLE
BUG: Fix QuickBundles clusters properties calls in IBs

### DIFF
--- a/challenge_scoring/io/streamlines.py
+++ b/challenge_scoring/io/streamlines.py
@@ -193,7 +193,7 @@ def save_invalid_connections(ib_info, streamlines, ic_clusters,
         out_strl = []
         for c_idx in v:
             out_strl.extend([s for s in np.array(streamlines)[
-                ic_clusters[c_idx]['indices']]])
+                ic_clusters[c_idx].indices]])
 
         if save_ibs:
             out_fname = os.path.join(out_segmented_dir,


### PR DESCRIPTION
Fix QuickBundles clusters properties calls when finding invalid bundles (IBs).

This was left behind in #6 because when that commit was pushed the test cases
used (the same ground truth was being used) did not yield any IBs.