### PR TITLE
ENH: Add CI through `GitHub Actions`

### DIFF
--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -1,0 +1,81 @@
+name: test, package
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      # max-parallel: 6
+      matrix:
+        os: [ubuntu-latest]
+        python-version: [3.8]
+        requires: ['minimal', 'latest']
+
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Set min. dependencies
+      if: matrix.requires == 'minimal'
+      run: |
+        python -c "req = open('requirements.txt').read().replace(' >= ', ' == ') ; open('requirements.txt', 'w').write(req)"
+
+    # - name: Cache pip
+    #   uses: actions/cache@v2
+    #   id: cache
+    #   with:
+    #     path: ${{ env.pythonLocation }}
+    #     # Look to see if there is a cache hit for the corresponding requirements files
+    #     key: ${{ env.pythonLocation }}-${{ hashFiles('requirements/*') }}
+    #     restore-keys: |
+    #       ${{ env.pythonLocation }}-
+
+    - name: Install dependencies
+      # if: steps.cache.outputs.cache-hit != 'true'
+      run: |
+        python -m pip install --upgrade --user pip
+        pip install -r requirements.txt
+        pip install -r requirements_dev.txt
+        python --version
+        pip --version
+        pip list
+
+    - name: Run tests
+      run: |
+        # tox --sitepackages
+        python setup.py build_ext --inplace
+        python -c 'import challenge_scoring'
+        # coverage run --source challenge_scoring -m pytest challenge_scoring -o junit_family=xunit2 -v --doctest-modules --junitxml=junit/test-results-${{ runner.os }}-${{ matrix.python-version }}.xml
+
+    - name: Upload pytest test results
+      uses: actions/upload-artifact@master
+      with:
+        name: pytest-results-${{ runner.os }}-${{ matrix.python-version }}
+        path: junit/test-results-${{ runner.os }}-${{ matrix.python-version }}.xml
+      # Use always() to always run this step to publish test results when there are test failures
+      if: always()
+
+    - name: Package Setup
+    # - name: Run tests with tox
+      run: |
+        pip install build
+        # check-manifest
+        python setup.py develop
+        # twine check dist/
+        # tox --sitepackages
+        # python -m tox
+
+    # - name: Statistics
+      # if: success()
+      # run: |
+      #   coverage report

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ISMRM 2015 Tractography Challenge Scoring system
 
+[![Build status](https://github.com/jhlegarreta/tractometer/actions/workflows/test_package.yml/badge.svg?branch=main)](https://github.com/jhlegarreta/tractometer/actions/workflows/test_package.yml?query=branch%3Amain)
+
 This system contains the scripts and tools that can be used to 
 recreate the results of the ISMRM 2015 Tractography Challenge and to
 evaluate new datasets.

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,0 +1,4 @@
+pytest==5.3.*
+pytest-cov
+pytest-xdist
+pytest-pep8


### PR DESCRIPTION
Add CI through `GitHub Actions`:
- Rework the `setup.py` so that the requirements can be installed (most
  notably `Cython`) prior to attempting to build the package.
- Add the necessary requirements for package testing.

Specify the language level for the Cythonization in `setup.py`. Fixes:
```
/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages/Cython/Compiler/Main.py:369:
FutureWarning: Cython directive 'language_level' not set, using 2 for now (Py2).
This will change in a later release!
File: /home/runner/work/tractometer/tractometer/challenge_scoring/tractanalysis/robust_streamlines_metrics.pyx
```

Add the corresponding status badge to the `README` file.