### PR TITLE
DOC: Fix build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ISMRM 2015 Tractography Challenge Scoring system
 
-[![Build status](https://github.com/jhlegarreta/tractometer/actions/workflows/test_package.yml/badge.svg?branch=main)](https://github.com/jhlegarreta/tractometer/actions/workflows/test_package.yml?query=branch%3Amain)
+[![test, package](https://github.com/jhlegarreta/tractometer/actions/workflows/test_package.yml/badge.svg)](https://github.com/jhlegarreta/tractometer/actions/workflows/test_package.yml)
 
 This system contains the scripts and tools that can be used to 
 recreate the results of the ISMRM 2015 Tractography Challenge and to


### PR DESCRIPTION
Fix build status badge: remove the non-existing `main` branch name and use the default branch.