### PR TITLE
ENH: Modernize package setup

### DIFF
--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Set min. dependencies
       if: matrix.requires == 'minimal'
       run: |
-        python -c "req = open('requirements.txt').read().replace(' >= ', ' == ') ; open('requirements.txt', 'w').write(req)"
+        python -c "req = open('pyproject.toml').read().replace(' >= ', ' == ') ; open('pyproject.toml', 'w').write(req)"
 
     # - name: Cache pip
     #   uses: actions/cache@v2
@@ -44,38 +44,24 @@ jobs:
       # if: steps.cache.outputs.cache-hit != 'true'
       run: |
         python -m pip install --upgrade --user pip
-        pip install -r requirements.txt
-        pip install -r requirements_dev.txt
+        pip install setuptools tox
         python --version
         pip --version
         pip list
 
     - name: Run tests
       run: |
+        # python -m tox
         # tox --sitepackages
+        pip install .[dependencies]
         python setup.py build_ext --inplace
         python -c 'import challenge_scoring'
-        # coverage run --source challenge_scoring -m pytest challenge_scoring -o junit_family=xunit2 -v --doctest-modules --junitxml=junit/test-results-${{ runner.os }}-${{ matrix.python-version }}.xml
 
-    - name: Upload pytest test results
-      uses: actions/upload-artifact@master
-      with:
-        name: pytest-results-${{ runner.os }}-${{ matrix.python-version }}
-        path: junit/test-results-${{ runner.os }}-${{ matrix.python-version }}.xml
-      # Use always() to always run this step to publish test results when there are test failures
-      if: always()
-
-    - name: Package Setup
-    # - name: Run tests with tox
+    - name: Build and install package
       run: |
-        pip install build
+        pip install -e .
         # check-manifest
         python setup.py develop
         # twine check dist/
         # tox --sitepackages
         # python -m tox
-
-    # - name: Statistics
-      # if: success()
-      # run: |
-      #   coverage report

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,95 @@
+[build-system]
+requires = [
+    "setuptools >= 66",
+    "wheel",
+    "setuptools_scm >= 6.4",
+    "Cython",
+    "numpy",
+]
+build-backend = "setuptools.build_meta"
+
+[project]
+authors = [
+  {name = "The challenge team"}, {email = "jean-christophe.houde@usherbrooke.ca"}
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Science/Research",
+    "Programming Language :: Python :: 3",
+    "Topic :: Scientific/Engineering :: Medical Science Apps.",
+]
+dependencies = [
+    "Cython",
+    "dipy",
+    "nibabel",
+    "numpy",
+    "scipy",
+]
+description = "Scoring system used for the ISMRM 2015 Tractography Challenge',"
+dynamic = ["version"]
+keywords = ["DWI, neuroimaging, tractography"]
+maintainers = [
+  {name = "Jon Haitz Legarreta"}, {email = "jon.haitz.legarreta@gmail.com"}
+]
+name = "tractometer"
+readme = "README.md"
+requires-python = ">=3.8"
+
+[project.optional-dependencies]
+test = [
+    "hypothesis >= 6.8.0",
+    "pytest == 7.2",
+    "pytest-cov",
+    "pytest-pep8",
+    "pytest-xdist",
+]
+dev = [
+    "black == 21.5b1",
+    "flake8 == 3.9.2",
+    "flake8-docstrings == 1.6.0",
+    "isort == 5.8.0",
+    "pre-commit >= 2.9.0",
+]
+
+[options.extras_require]
+all = [
+    "%(test)s",
+]
+
+[project.urls]
+homepage = "https://github.com/jhlegarreta/tractometer"
+documentation = "https://github.com/jhlegarreta/tractometer"
+repository = "https://github.com/jhlegarreta/tractometer"
+
+[tool.black]
+line-length = 79
+target-version = ["py38"]
+exclude ='''
+(
+  /(
+      \.eggs        # exclude a few common directories in the
+    | \.git         # root of the project
+    | \.hg
+    | \.mypy_cache
+    | \.tox
+    | \.venv
+    | _build
+    | buck-out
+    | build
+    | dist
+  )/
+  | data            # also separately exclude project-specific files
+                    # and folders in the root of the project
+)
+'''
+
+[tool.isort]
+profile = "black"
+line_length = 79
+src_paths = ["challenge_scoring"]
+
+[tool.setuptools.packages]
+find = {}  # Scanning implicit namespaces is active by default
+
+[tool.setuptools_scm]
+write_to = "challenge_scoring/_version.py"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,0 @@
-setuptools
-numpy
-scipy
-nibabel
-Cython
-dipy

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,0 @@
-pytest==5.3.*
-pytest-cov
-pytest-xdist
-pytest-pep8

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,21 @@
+[flake8]
+max-line-length = 79
+doctests = True
+docstring-convention = numpy
+exclude = .tox,*.egg,build,temp
+verbose = 2
+# https://pep8.readthedocs.io/en/latest/intro.html#error-codes
+format = pylint
+ignore =
+    # D100,  # D100 - missing docstring in public module
+    # D104,  # D104 - missing docstring in public package
+    # D107,  # D107 - missing docstring in __init__
+    D,     # Ignore all docstrings
+    E203,  # E203 - whitespace before ':'. Opposite convention enforced by black
+    E231,  # E231 - missing whitespace after ',', ';', or ':'; for black
+    E501,  # E501 - line too long. Handled by black, we have longer lines
+    W503   # W503 - line break before binary operator, need for black
+extend-ignore =
+    D103   ./* # D103 - missing docstring in public function
+extend-select =
+    D404  # D404 - first word of the docstring should not be `This`

--- a/setup.py
+++ b/setup.py
@@ -5,18 +5,6 @@ from glob import glob
 from setuptools import setup, Extension
 from setuptools.command.build_ext import build_ext
 
-
-with open('requirements.txt') as f:
-    required_dependencies = f.read().splitlines()
-    external_dependencies = []
-    for dependency in required_dependencies:
-        if dependency[0:2] == '-e':
-            repo_name = dependency.split('=')[-1]
-            repo_url = dependency[3:]
-            external_dependencies.append('{} @ {}'.format(repo_name, repo_url))
-        else:
-            external_dependencies.append(dependency)
-
 ext_modules = [
     Extension(
         'challenge_scoring.tractanalysis.robust_streamlines_metrics',
@@ -51,24 +39,9 @@ class CustomBuildExtCommand(build_ext):
 
 
 opts = dict(
-    name='tractometer', version='1.0.1',
-    description='Scoring system used for the ISMRM 2015 Tractography Challenge',
-    url='https://github.com/scilus/ismrm_2015_tractography_challenge_scoring',
     ext_modules=ext_modules,
-    author='The challenge team',
-    author_email='jean-christophe.houde@usherbrooke.ca',
-    packages=[
-        'challenge_scoring',
-        'challenge_scoring.io',
-        'challenge_scoring.metrics',
-        'challenge_scoring.tractanalysis',
-        'challenge_scoring.utils'
-    ],
     cmdclass={'build_ext': CustomBuildExtCommand},
-    setup_requires=['Cython'],
     scripts=glob('scripts/*.py'),
-    install_requires=external_dependencies,
-    requires=['numpy', 'scipy']
 )
 
 setup(**opts)

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,41 @@
+[tox]
+envlist = py38
+isolated_build = true
+
+[testenv]
+commands = python -m pytest
+deps = pytest-cov
+extras = test
+
+[testenv:isort]
+skip_install = true
+deps = pre-commit
+commands = pre-commit run isort --all-files
+
+[testenv:flake8]
+skip_install = true
+deps = pre-commit
+commands = pre-commit run flake8 --all-files
+
+[testenv:black]
+skip_install = true
+deps = pre-commit
+commands = pre-commit run black --all-files
+
+[testenv:import-lint]
+skip_install = true
+deps = pre-commit
+commands = pre-commit run --hook-stage manual import-linter --all-files
+
+[testenv:package]
+isolated_build = true
+skip_install = true
+deps =
+    # check_manifest
+    wheel
+    # twine
+    build
+commands =
+    # check-manifest
+    python -m build
+    # python -m twine check dist/*


### PR DESCRIPTION
Modernize package setup: adopt PEP 518 and partially 631.

Adopt PEP518 to specify minimum build system requirements for the
package.

Partially comply with PEP631:
- Dependencies are now stored in the `pyproject.toml` file.
- The Cythonization is kept in the `setup.py` file.
- Describing the `flake8` configuration in the `pyproject.toml` is not
  supported yet, so it is kept in the `setup.cfg` file.

The testing and packaging is not yet done through `tox` since the
package has no tests at present and `tox` finishes with a failure as a
consequence.

Documentation:
https://www.python.org/dev/peps/pep-0518/
https://www.python.org/dev/peps/pep-0631/