### PR TITLE
ENH: Pin `NumPy` version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "Cython",
     "dipy",
     "nibabel",
-    "numpy",
+    "numpy == 1.20.3",
     "scipy",
 ]
 description = "Scoring system used for the ISMRM 2015 Tractography Challenge',"


### PR DESCRIPTION
Pin `NumPy` version to a version lower than 1.21 to avoid conflicts when installing the package to be used in `tractolearn` and due to the version requirements of `scilpy`. Avoids:
```
______ ERROR collecting tractolearn/scripts/compute_tractometer_scores.py ______
tractolearn/scripts/compute_tractometer_scores.py:9: in <module>
    from challenge_scoring.metrics import bundle_coverage, valid_connections
/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages/challenge_scoring/metrics/bundle_coverage.py:8: in <module>
    from challenge_scoring.tractanalysis.robust_streamlines_metrics \
challenge_scoring/tractanalysis/robust_streamlines_metrics.pyx:1: in init challenge_scoring.tractanalysis.robust_streamlines_metrics
    ???
E   ValueError: numpy.ndarray size changed, may indicate binary incompatibility. Expected 96 from C header, got 88 from PyObject
```

raised in `tractolearn` after 875c567dcd1c37c4ec33ee14c6fc9bc6c7769c89.