### PR TITLE
ENH: Adopt PEP518

### DIFF
--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Set min. dependencies
       if: matrix.requires == 'minimal'
       run: |
-        python -c "req = open('requirements.txt').read().replace(' >= ', ' == ') ; open('requirements.txt', 'w').write(req)"
+        python -c "req = open('setup.cfg').read().replace(' >= ', ' == ') ; open('setup.cfg', 'w').write(req)"
 
     # - name: Cache pip
     #   uses: actions/cache@v2
@@ -44,16 +44,15 @@ jobs:
       # if: steps.cache.outputs.cache-hit != 'true'
       run: |
         python -m pip install --upgrade --user pip
-        pip install -r requirements.txt
-        pip install -r requirements_dev.txt
+        pip install setuptools
         python --version
         pip --version
         pip list
 
     - name: Run tests
       run: |
+        pip install -e .[testing]
         # tox --sitepackages
-        python setup.py build_ext --inplace
         python -c 'import challenge_scoring'
         # coverage run --source challenge_scoring -m pytest challenge_scoring -o junit_family=xunit2 -v --doctest-modules --junitxml=junit/test-results-${{ runner.os }}-${{ matrix.python-version }}.xml
 
@@ -70,10 +69,8 @@ jobs:
       run: |
         pip install build
         # check-manifest
-        python setup.py develop
-        # twine check dist/
-        # tox --sitepackages
-        # python -m tox
+        python -m build
+        # twine check dist/*
 
     # - name: Statistics
       # if: success()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,35 @@
+[build-system]
+requires = [
+    "setuptools >= 66",
+    "wheel",
+    "setuptools_scm >= 6.4",
+    "Cython",
+    "numpy",
+]
+build-backend = "setuptools.build_meta"
+
+[tool.black]
+line-length = 79
+target-version = ["py38"]
+exclude ='''
+(
+  /(
+      \.eggs        # exclude a few common directories in the
+    | \.git         # root of the project
+    | \.hg
+    | \.mypy_cache
+    | \.tox
+    | \.venv
+    | _build
+    | buck-out
+    | build
+    | dist
+  )/
+  | data            # also separately exclude project-specific files
+                    # and folders in the root of the project
+)
+'''
+[tool.isort]
+profile = "black"
+line_length = 79
+src_paths = ["challenge_scoring"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,0 @@
-setuptools
-numpy
-scipy
-nibabel
-Cython
-dipy

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,0 @@
-pytest==5.3.*
-pytest-cov
-pytest-xdist
-pytest-pep8

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,61 @@
+[metadata]
+author = The challenge team
+author_email = jean-christophe.houde@usherbrooke.ca
+classifiers =
+    Development Status :: 3 - Alpha
+    Intended Audience :: Science/Research
+    Programming Language :: Python :: 3
+    Topic :: Scientific/Engineering :: Medical Science Apps.
+description = Scoring system used for the ISMRM 2015 Tractography Challenge
+download_url = https://github.com/scilus/ismrm_2015_tractography_challenge_scoring'
+keywords = DWI, neuroimaging, tractography
+long_description = file: README.md
+maintainer = Jon Haitz Legarreta
+maintainer_email = jon.haitz.legarreta@gmail.com
+name = tractometer
+
+[options]
+zip_safe = False
+packages = find:
+python_requires = >=3.6
+include_package_data = True
+install_requires =
+    Cython
+    numpy
+    scipy
+
+[options.extras_require]
+testing =
+    pytest == 5.3.*
+    pytest-cov
+    pytest-pep8
+    pytest-xdist
+dev =
+    black == 22.3.0
+    flake8 == 3.9.2
+    flake8-docstrings == 1.6.0
+    isort == 5.8.0
+    pre-commit >= 2.9.0
+    %(testing)s
+
+[flake8]
+max-line-length = 79
+doctests = True
+docstring-convention = numpy
+exclude = .tox,*.egg,build,temp
+verbose = 2
+# https://pep8.readthedocs.io/en/latest/intro.html#error-codes
+format = pylint
+ignore =
+    # D100,  # D100 - missing docstring in public module
+    # D104,  # D104 - missing docstring in public package
+    # D107,  # D107 - missing docstring in __init__
+    D,     # Ignore all docstrings
+    E203,  # E203 - whitespace before ':'. Opposite convention enforced by black
+    E231,  # E231 - missing whitespace after ',', ';', or ':'; for black
+    E501,  # E501 - line too long. Handled by black, we have longer lines
+    W503   # W503 - line break before binary operator, need for black
+extend-ignore =
+    D103   ./* # D103 - missing docstring in public function
+extend-select =
+    D404  # D404 - first word of the docstring should not be `This`

--- a/setup.py
+++ b/setup.py
@@ -5,18 +5,6 @@ from glob import glob
 from setuptools import setup, Extension
 from setuptools.command.build_ext import build_ext
 
-
-with open('requirements.txt') as f:
-    required_dependencies = f.read().splitlines()
-    external_dependencies = []
-    for dependency in required_dependencies:
-        if dependency[0:2] == '-e':
-            repo_name = dependency.split('=')[-1]
-            repo_url = dependency[3:]
-            external_dependencies.append('{} @ {}'.format(repo_name, repo_url))
-        else:
-            external_dependencies.append(dependency)
-
 ext_modules = [
     Extension(
         'challenge_scoring.tractanalysis.robust_streamlines_metrics',
@@ -51,12 +39,7 @@ class CustomBuildExtCommand(build_ext):
 
 
 opts = dict(
-    name='tractometer', version='1.0.1',
-    description='Scoring system used for the ISMRM 2015 Tractography Challenge',
-    url='https://github.com/scilus/ismrm_2015_tractography_challenge_scoring',
     ext_modules=ext_modules,
-    author='The challenge team',
-    author_email='jean-christophe.houde@usherbrooke.ca',
     packages=[
         'challenge_scoring',
         'challenge_scoring.io',
@@ -65,10 +48,7 @@ opts = dict(
         'challenge_scoring.utils'
     ],
     cmdclass={'build_ext': CustomBuildExtCommand},
-    setup_requires=['Cython'],
     scripts=glob('scripts/*.py'),
-    install_requires=external_dependencies,
-    requires=['numpy', 'scipy']
 )
 
 setup(**opts)

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,41 @@
+[tox]
+envlist = py38
+isolated_build = true
+
+[testenv]
+commands = python -m pytest
+deps = pytest-cov
+extras = testing
+
+[testenv:isort]
+skip_install = True
+deps = pre-commit
+commands = pre-commit run isort --all-files
+
+[testenv:flake8]
+skip_install = True
+deps = pre-commit
+commands = pre-commit run flake8 --all-files
+
+[testenv:black]
+skip_install = True
+deps = pre-commit
+commands = pre-commit run black --all-files
+
+[testenv:import-lint]
+skip_install = True
+deps = pre-commit
+commands = pre-commit run --hook-stage manual import-linter --all-files
+
+[testenv:package]
+isolated_build = true
+skip_install = true
+deps =
+    # check_manifest
+    wheel
+    # twine
+    build
+commands =
+    # check-manifest
+    python -m build
+    # python -m twine check dist/*


### PR DESCRIPTION
Adopt PEP518 to specify minimum build system requirements for the package.

Adopt setuptools_scm` versioning system:
- Host package static metadata in `setup.cfg`.
- Host package dependiencies in `setup.cfg`.

Allows to reduce the number of files containing package configuration data:
- Requirements are directly hosted in `setup.cfg` and thus `requirements*.txt` files are no longer necessary.

Change the package testing worfklow accordingly.

Documentation:
https://www.python.org/dev/peps/pep-0518/