### PR TITLE
ENH: Test package using Python 3.10; drop 3.8

### DIFF
--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -11,7 +11,7 @@ jobs:
       # max-parallel: 6
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.8]
+        python-version: ['3.10']
         requires: ['minimal', 'latest']
 
     steps:

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,4 @@
-pytest==5.3.*
+pytest>=7.2.*
 pytest-cov
 pytest-xdist
 pytest-pep8


### PR DESCRIPTION
Test package using Python 3.10; drop testing using 3.8.