### PR TITLE
ENH: Modernize package setup

### DIFF
--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Set min. dependencies
       if: matrix.requires == 'minimal'
       run: |
-        python -c "req = open('requirements.txt').read().replace(' >= ', ' == ') ; open('requirements.txt', 'w').write(req)"
+        python -c "req = open('pyproject.toml').read().replace(' >= ', ' == ') ; open('pyproject.toml', 'w').write(req)"
 
     # - name: Cache pip
     #   uses: actions/cache@v2
@@ -44,18 +44,16 @@ jobs:
       # if: steps.cache.outputs.cache-hit != 'true'
       run: |
         python -m pip install --upgrade --user pip
-        pip install -r requirements.txt
-        pip install -r requirements_dev.txt
+        pip install setuptools tox
+        pip install -e .[test]
         python --version
         pip --version
         pip list
-
     - name: Run tests
       run: |
         # tox --sitepackages
-        python setup.py build_ext --inplace
         python -c 'import challenge_scoring'
-        # coverage run --source challenge_scoring -m pytest challenge_scoring -o junit_family=xunit2 -v --doctest-modules --junitxml=junit/test-results-${{ runner.os }}-${{ matrix.python-version }}.xml
+        # coverage run --source challenge_scoring -m pytest challenge_scoring -o junit_family=xunit2 -v --doctest-modules --durations=10 --junitxml=junit/test-results-${{ runner.os }}-${{ matrix.python-version }}.xml
 
     - name: Upload pytest test results
       uses: actions/upload-artifact@master
@@ -65,17 +63,17 @@ jobs:
       # Use always() to always run this step to publish test results when there are test failures
       if: always()
 
+    # - name: Statistics
+    #  if: success()
+    #  run: |
+    #     coverage report
+
     - name: Package Setup
     # - name: Run tests with tox
       run: |
         pip install build
         # check-manifest
-        python setup.py develop
+        python -m build
         # twine check dist/
         # tox --sitepackages
         # python -m tox
-
-    # - name: Statistics
-      # if: success()
-      # run: |
-      #   coverage report

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,53 @@
+default_language_version:
+  python: python3.10
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.4.0
+    hooks:
+      - id: check-added-large-files
+        name: check-added-large-files
+        description: Prevent giant files from being committed.
+      - id: check-ast
+        name: check-ast
+        description: Simply check whether files parse as valid python.
+      - id: check-case-conflict
+      - id: check-docstring-first
+      - id: check-executables-have-shebangs
+      - id: check-merge-conflict
+        name: check-merge-conflict
+        description: Check for files that contain merge conflict strings.
+      - id: check-toml
+      - id: check-yaml
+        exclude: .github/workflows
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+      - id: requirements-txt-fixer
+        name: requirements-txt-fixer
+        description: Sorts entries in requirements.txt
+      - id: trailing-whitespace
+
+  - repo: https://github.com/timothycrosley/isort
+    rev: 5.11.5
+    hooks:
+      - id: isort
+        name: isort
+        args: [--settings-path, ./pyproject.toml]
+        types: [python]
+
+  - repo: https://github.com/psf/black
+    rev: 22.3.0
+    hooks:
+      - id: black
+        name: black
+        args: [--config, ./pyproject.toml]
+        types: [python]
+
+  - repo: https://github.com/pycqa/flake8
+    rev: 3.9.2
+    hooks:
+      - id: flake8
+        name: flake8
+        additional_dependencies: [flake8-docstrings==1.6.0]
+        args: [--config, ./setup.cfg]
+        types: [python]

--- a/challenge_scoring/__init__.py
+++ b/challenge_scoring/__init__.py
@@ -1,1 +1,6 @@
 NB_POINTS_RESAMPLE = 12
+
+try:
+    from ._version import version as __version__
+except ImportError:
+    __version__ = "not-installed"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,99 @@
+[build-system]
+requires = [
+    "setuptools >= 66",
+    "wheel",
+    "setuptools_scm >= 6.4",
+    "Cython",
+    "numpy",
+
+]
+build-backend = "setuptools.build_meta"
+
+[project]
+authors = [
+  {name = "The challenge team"}, {email = "jean-christophe.houde@usherbrooke.ca"}
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Science/Research",
+    "Programming Language :: Python :: 3",
+    "Topic :: Scientific/Engineering :: Medical Science Apps.",
+]
+dependencies = [
+    "Cython",
+    "dipy",
+    "nibabel",
+    "numpy",
+    "scipy",
+]
+description = "Scoring system used for the ISMRM 2015 Tractography Challenge"
+dynamic = ["version"]
+keywords = ["DWI, neuroimaging, tractography"]
+maintainers = [
+  {name = "Jon Haitz Legarreta"}, {email = "jon.haitz.legarreta@gmail.com"}
+]
+name = "challenge_scoring"
+readme = "README.md"
+requires-python = ">=3.10"
+
+[project.optional-dependencies]
+test = [
+    "hypothesis >= 6.8.0",
+    "pytest == 7.2.0",
+    "pytest-cov",
+    "pytest-pep8",
+    "pytest-xdist",
+]
+dev = [
+    "black == 21.5b1",
+    "flake8 == 3.9.2",
+    "flake8-docstrings == 1.6.0",
+    "isort == 5.11.5",
+    "pre-commit >= 2.9.0",
+]
+
+[project.scripts]
+score_tractogram = "scripts:score_tractogram.main"
+
+[options.extras_require]
+all = [
+    "%(test)s",
+]
+
+[project.urls]
+homepage = "https://github.com/scilus/ismrm_2015_tractography_challenge_scoring"
+documentation = "https://github.com/scilus/ismrm_2015_tractography_challenge_scoring"
+repository = "https://github.com/scilus/ismrm_2015_tractography_challenge_scoring"
+
+[tool.black]
+line-length = 79
+target-version = ["py310"]
+exclude ='''
+(
+  /(
+      \.eggs        # exclude a few common directories in the
+    | \.git         # root of the project
+    | \.hg
+    | \.mypy_cache
+    | \.tox
+    | \.venv
+    | _build
+    | buck-out
+    | build
+    | dist
+  )/
+  | data            # also separately exclude project-specific files
+                    # and folders in the root of the project
+)
+'''
+
+[tool.isort]
+profile = "black"
+line_length = 79
+src_paths = ["challenge_scoring"]
+
+[tool.setuptools.packages]
+find = {}  # Scanning implicit namespaces is active by default
+
+[tool.setuptools_scm]
+write_to = "challenge_scoring/_version.py"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,0 @@
-setuptools
-numpy
-scipy
-nibabel
-Cython
-dipy

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,0 @@
-pytest>=7.2.*
-pytest-cov
-pytest-xdist
-pytest-pep8

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,21 @@
+[flake8]
+max-line-length = 79
+doctests = True
+docstring-convention = numpy
+exclude = .tox,*.egg,build,temp
+verbose = 2
+# https://pep8.readthedocs.io/en/latest/intro.html#error-codes
+format = pylint
+ignore =
+    # D100,  # D100 - missing docstring in public module
+    # D104,  # D104 - missing docstring in public package
+    # D107,  # D107 - missing docstring in __init__
+    D,     # Ignore all docstrings
+    E203,  # E203 - whitespace before ':'. Opposite convention enforced by black
+    E231,  # E231 - missing whitespace after ',', ';', or ':'; for black
+    E501,  # E501 - line too long. Handled by black, we have longer lines
+    W503   # W503 - line break before binary operator, need for black
+extend-ignore =
+    D103   ./* # D103 - missing docstring in public function
+extend-select =
+    D404  # D404 - first word of the docstring should not be `This`

--- a/setup.py
+++ b/setup.py
@@ -5,25 +5,12 @@ from glob import glob
 from setuptools import setup, Extension
 from setuptools.command.build_ext import build_ext
 
-
-with open('requirements.txt') as f:
-    required_dependencies = f.read().splitlines()
-    external_dependencies = []
-    for dependency in required_dependencies:
-        if dependency[0:2] == '-e':
-            repo_name = dependency.split('=')[-1]
-            repo_url = dependency[3:]
-            external_dependencies.append('{} @ {}'.format(repo_name, repo_url))
-        else:
-            external_dependencies.append(dependency)
-
 ext_modules = [
     Extension(
         'challenge_scoring.tractanalysis.robust_streamlines_metrics',
         ['challenge_scoring/tractanalysis/robust_streamlines_metrics.pyx']
     )
 ]
-
 
 class CustomBuildExtCommand(build_ext):
     """Build_ext command to use when numpy headers are needed."""
@@ -51,24 +38,8 @@ class CustomBuildExtCommand(build_ext):
 
 
 opts = dict(
-    name='tractometer', version='1.0.1',
-    description='Scoring system used for the ISMRM 2015 Tractography Challenge',
-    url='https://github.com/scilus/ismrm_2015_tractography_challenge_scoring',
     ext_modules=ext_modules,
-    author='The challenge team',
-    author_email='jean-christophe.houde@usherbrooke.ca',
-    packages=[
-        'challenge_scoring',
-        'challenge_scoring.io',
-        'challenge_scoring.metrics',
-        'challenge_scoring.tractanalysis',
-        'challenge_scoring.utils'
-    ],
     cmdclass={'build_ext': CustomBuildExtCommand},
-    setup_requires=['Cython'],
-    scripts=glob('scripts/*.py'),
-    install_requires=external_dependencies,
-    requires=['numpy', 'scipy']
 )
 
 setup(**opts)

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,41 @@
+[tox]
+envlist = py310
+isolated_build = true
+
+[testenv]
+commands = python -m pytest --cov
+deps = pytest-cov
+extras = test
+
+[testenv:isort]
+skip_install = true
+deps = pre-commit
+commands = pre-commit run isort --all-files
+
+[testenv:flake8]
+skip_install = true
+deps = pre-commit
+commands = pre-commit run flake8 --all-files
+
+[testenv:black]
+skip_install = true
+deps = pre-commit
+commands = pre-commit run black --all-files
+
+[testenv:import-lint]
+skip_install = true
+deps = pre-commit
+commands = pre-commit run --hook-stage manual import-linter --all-files
+
+[testenv:package]
+isolated_build = true
+skip_install = true
+deps =
+    # check_manifest
+    wheel
+    # twine
+    build
+commands =
+    # check-manifest
+    python -m build
+    # python -m twine check dist/*


### PR DESCRIPTION
Modernize package setup:
- Adopt PEP621 to specify prject metadata: host package static metadata and dependiencies in `pyproject.toml`.
- Adopt PEP518 to specify minimum build system requirements for the package.

Documentation:
https://www.python.org/dev/peps/pep-0518/
https://packaging.python.org/en/latest/specifications/declaring-project-metadata/#declaring-project-metadata

Transition to `setuptools_scm` versioning system.

Provide a non-empty version for downloaded source packaging cases.

Change the package testing worfklow accordingly.

Add a pre-commit configuration file to check style/format code.