### PR TITLE
ENH: Pin `Cython` and `NumPy` dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,8 @@ requires = [
     "setuptools >= 66",
     "wheel",
     "setuptools_scm >= 6.4",
-    "Cython",
-    "numpy",
+    "Cython == 0.29.37",
+    "numpy == 1.23.5",
 
 ]
 build-backend = "setuptools.build_meta"
@@ -20,10 +20,10 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Medical Science Apps.",
 ]
 dependencies = [
-    "Cython",
+    "Cython == 0.29.37",
     "dipy",
     "nibabel",
-    "numpy",
+    "numpy == 1.23.5",
     "scipy",
 ]
 description = "Scoring system used for the ISMRM 2015 Tractography Challenge"


### PR DESCRIPTION
Pin `Cython` and `NumPy` dependencies to their latest versions in the 0.29.x and 1.23.x series, respectively.

`tractolearn` is failing to build `tractometer` due to the error:
```
 Error compiling Cython file:
      ------------------------------------------------------------
      ...

          # This array counts the number of different tracks going through each voxel.
          # Need to keep both the array and the memview on it to be able to
          # reshape and return in the end.
          traversal_tags = np.zeros((n_voxels,), dtype=np.int)
          cdef np.int_t[:] traversal_tags_v = traversal_tags
               ^
      ------------------------------------------------------------

      challenge_scoring/tractanalysis/robust_streamlines_metrics.pyx:54:9: 'int_t' is not a type identifier
```

This has been happening for `SCILPY` today (both `tractometer` and `SCILPT` share this code), and the only workaround to make `SCILPY` build for `tractolearn` in GHA was to bump `SCILPY` to 2.0.0.

This problem has not been happening in a local build (Ubuntu 22.04 and Python 3.10), but in a GHA environment these could not be replicated.